### PR TITLE
38 branch updates

### DIFF
--- a/agent/install-sysmon-beats.ps1
+++ b/agent/install-sysmon-beats.ps1
@@ -44,9 +44,18 @@ param (
 
 if (-NOT ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator"))
 {
-  $arguments = "& '" +$myinvocation.mycommand.definition + "'", $args
-  Start-Process powershell -Verb runAs -ArgumentList $arguments
-  Break
+    # Use param values instead of $args because $args doesn't appear to get populated if param values are specified
+    # Also set the ExecutionPolicy to Bypass otherwise this will likely fail as script
+    # execution is disabled by default.
+    $arguments = "-ExecutionPolicy", "Bypass", "-File", $myinvocation.mycommand.definition , $RedisHost, $RedisPort
+    if($RedisPassword) 
+    {
+        # Only add this argument if the user provided it, otherwise it will be blank and will cause an error
+        $arguments += $RedisPassword
+    }
+  
+    Start-Process -FilePath powershell -Verb runAs -ArgumentList $arguments
+    Break
 }
 
 if (-not (Test-Path "$Env:programfiles\Sysmon" -PathType Container)) {

--- a/agent/install-sysmon-beats.ps1
+++ b/agent/install-sysmon-beats.ps1
@@ -47,7 +47,7 @@ if (-NOT ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdenti
     # Use param values instead of $args because $args doesn't appear to get populated if param values are specified
     # Also set the ExecutionPolicy to Bypass otherwise this will likely fail as script
     # execution is disabled by default.
-    $arguments = "-ExecutionPolicy", "Bypass", "-File", $myinvocation.mycommand.definition , $RedisHost, $RedisPort
+    $arguments = "-ExecutionPolicy", "Bypass", "-File", $myinvocation.mycommand.definition, $RedisHost, $RedisPort
     if($RedisPassword) 
     {
         # Only add this argument if the user provided it, otherwise it will be blank and will cause an error


### PR DESCRIPTION
Closes #38

Manually tested to ensure that folder permissions are properly set for the %PROGRAMDATA$\winlogbeat folder.

Manually tested running the install script as a non-admin user and passed in values for each parameter (host, port, password), elevating privileges via the prompt that is given, checked that the script appeared to finish, and checked that the logs were being received on the remote Espy server.