### PR TITLE
Fix Missing Directory Issue for Installation

### DIFF
--- a/agent/install-sysmon-beats.ps1
+++ b/agent/install-sysmon-beats.ps1
@@ -243,22 +243,22 @@ if (-not (Test-Path "$Env:programfiles\winlogbeat*" -PathType Container)) {
 Set-Location "$Env:programfiles\winlogbeat*\"
 
 # Create the keystore if it doesn't exist
-if (-not (Test-Path -PathType Leaf "C:\ProgramData\winlogbeat\winlogbeat.keystore")) {
-    .\winlogbeat.exe --path.data "C:\ProgramData\winlogbeat" keystore create
+if (-not (Test-Path -PathType Leaf "$Env:ProgramData\winlogbeat\winlogbeat.keystore")) {
+    .\winlogbeat.exe --path.data "$Env:ProgramData\winlogbeat" keystore create
 }
 
 # Set the Redis password if it doesn't exist
-if ((.\winlogbeat.exe --path.data "C:\ProgramData\winlogbeat" keystore list | Select-String REDIS_PASSWORD).Matches.Length -eq 0) {
+if ((.\winlogbeat.exe --path.data "$Env:ProgramData\winlogbeat" keystore list | Select-String REDIS_PASSWORD).Matches.Length -eq 0) {
     if($RedisPassword) {
-        Write-Output "$RedisPassword" | .\winlogbeat.exe --path.data "C:\ProgramData\winlogbeat" keystore add REDIS_PASSWORD --stdin
+        Write-Output "$RedisPassword" | .\winlogbeat.exe --path.data "$Env:ProgramData\winlogbeat" keystore add REDIS_PASSWORD --stdin
     } else {
-        .\winlogbeat.exe --path.data "C:\ProgramData\winlogbeat" keystore add REDIS_PASSWORD
+        .\winlogbeat.exe --path.data "$Env:ProgramData\winlogbeat" keystore add REDIS_PASSWORD
     }
 }
 
-# Set ACL's of the C:\ProgramData\winlogbeat folder to be the same as C:\ProgramFiles\winlogbeat* (the main install path)
-# This helps ensure that "normal" users aren't able to access the C:\ProgramData\winlogbeat folder
-Get-ACL -Path "C:\ProgramFiles\winlogbeat*" | Set-ACL -Path "C:\ProgramData\winlogbeat"
+# Set ACL's of the $Env:ProgramData\winlogbeat folder to be the same as $Env:ProgramFiles\winlogbeat* (the main install path)
+# This helps ensure that "normal" users aren't able to access the $Env:ProgramData\winlogbeat folder
+Get-ACL -Path "$Env:ProgramFiles\winlogbeat*" | Set-ACL -Path "$Env:ProgramData\winlogbeat"
  
 # Backup winlogbeat config if it exists
 if (Test-Path -PathType Leaf .\winlogbeat.yml) {

--- a/agent/install-sysmon-beats.ps1
+++ b/agent/install-sysmon-beats.ps1
@@ -71,6 +71,14 @@ if (-NOT ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdenti
     Break
 }
 
+# Copy Sysmon into Program Files if it doesn't already exist
+if (-not (Test-Path "$Env:programfiles\Sysmon" -PathType Container)) {
+    Invoke-WebRequest -OutFile Sysmon.zip https://download.sysinternals.com/files/Sysmon.zip
+    Expand-Archive .\Sysmon.zip
+    rm .\Sysmon.zip
+    mv .\Sysmon\ "$Env:programfiles"
+}
+
 # Set SysmonConfig by querying Sysmon if it has already been installed
 if ($SysmonConfig -eq "" -and (Test-Path "$Env:windir\Sysmon64.exe" -PathType Leaf)) {
     $oldConfigPathLine = (& "$Env:windir\Sysmon64.exe" "-c" | Select-String " - Config file:").Line
@@ -213,14 +221,6 @@ if ($SysmonConfig -ne "" -and (Test-Path "$SysmonConfig" -PathType Leaf)) {
     </EventFiltering>
 </Sysmon>
 "@ > "$Env:programfiles\Sysmon\sysmon-espy.xml"
-}
-
-# Copy Sysmon into Program Files if it doesn't already exist
-if (-not (Test-Path "$Env:programfiles\Sysmon" -PathType Container)) {
-    Invoke-WebRequest -OutFile Sysmon.zip https://download.sysinternals.com/files/Sysmon.zip
-    Expand-Archive .\Sysmon.zip
-    rm .\Sysmon.zip
-    mv .\Sysmon\ "$Env:programfiles"
 }
 
 # Load the new sysmon configuration and install the service if needed

--- a/agent/install-sysmon-beats.ps1
+++ b/agent/install-sysmon-beats.ps1
@@ -256,9 +256,9 @@ if ((.\winlogbeat.exe --path.data "C:\ProgramData\winlogbeat" keystore list | Se
     }
 }
 
-# Set ACL's of the $Env:ProgramData\winlogbeat folder to be the same as $Env:ProgramFiles\winlogbeat* (the main install path)
-# This helps ensure that "normal" users aren't able to access the $Env:ProgramData\winlogbeat folder
-Get-ACL -Path "$Env:ProgramFiles\winlogbeat*" | Set-ACL -Path "$Env:ProgramData\winlogbeat"
+# Set ACL's of the C:\ProgramData\winlogbeat folder to be the same as C:\ProgramFiles\winlogbeat* (the main install path)
+# This helps ensure that "normal" users aren't able to access the C:\ProgramData\winlogbeat folder
+Get-ACL -Path "C:\ProgramFiles\winlogbeat*" | Set-ACL -Path "C:\ProgramData\winlogbeat"
  
 # Backup winlogbeat config if it exists
 if (Test-Path -PathType Leaf .\winlogbeat.yml) {

--- a/agent/install-sysmon-beats.ps1
+++ b/agent/install-sysmon-beats.ps1
@@ -242,24 +242,6 @@ if (-not (Test-Path "$Env:programfiles\winlogbeat*" -PathType Container)) {
 # Begin winlogbeat configuration
 Set-Location "$Env:programfiles\winlogbeat*\"
 
-# Create the keystore if it doesn't exist
-if (-not (Test-Path -PathType Leaf "$Env:ProgramData\winlogbeat\winlogbeat.keystore")) {
-    .\winlogbeat.exe --path.data "$Env:ProgramData\winlogbeat" keystore create
-}
-
-# Set the Redis password if it doesn't exist
-if ((.\winlogbeat.exe --path.data "$Env:ProgramData\winlogbeat" keystore list | Select-String REDIS_PASSWORD).Matches.Length -eq 0) {
-    if($RedisPassword) {
-        Write-Output "$RedisPassword" | .\winlogbeat.exe --path.data "$Env:ProgramData\winlogbeat" keystore add REDIS_PASSWORD --stdin
-    } else {
-        .\winlogbeat.exe --path.data "$Env:ProgramData\winlogbeat" keystore add REDIS_PASSWORD
-    }
-}
-
-# Set ACL's of the $Env:ProgramData\winlogbeat folder to be the same as $Env:ProgramFiles\winlogbeat* (the main install path)
-# This helps ensure that "normal" users aren't able to access the $Env:ProgramData\winlogbeat folder
-Get-ACL -Path "$Env:ProgramFiles\winlogbeat*" | Set-ACL -Path "$Env:ProgramData\winlogbeat"
- 
 # Backup winlogbeat config if it exists
 if (Test-Path -PathType Leaf .\winlogbeat.yml) {
     Copy-Item .\winlogbeat.yml .\winlogbeat.yml.bak
@@ -315,6 +297,23 @@ if ((Test-Path -PathType Leaf .\winlogbeat.yml) -and
 } else {
     Write-Output "" >> .\winlogbeat.yml
     Write-Output "$winlogbeatRedisCfg" >> .\winlogbeat.yml
+}
+
+# Create the keystore if it doesn't exist
+if (-not (Test-Path -PathType Leaf "$Env:ProgramData\winlogbeat\winlogbeat.keystore")) {
+    .\winlogbeat.exe --path.data "$Env:ProgramData\winlogbeat" keystore create
+    # Set ACL's of the $Env:ProgramData\winlogbeat folder to be the same as $Env:ProgramFiles\winlogbeat* (the main install path)
+    # This helps ensure that "normal" users aren't able to access the $Env:ProgramData\winlogbeat folder
+    Get-ACL -Path "$Env:ProgramFiles\winlogbeat*" | Set-ACL -Path "$Env:ProgramData\winlogbeat"
+}
+
+# Set the Redis password if it doesn't exist
+if ((.\winlogbeat.exe --path.data "$Env:ProgramData\winlogbeat" keystore list | Select-String REDIS_PASSWORD).Matches.Length -eq 0) {
+    if($RedisPassword) {
+        Write-Output "$RedisPassword" | .\winlogbeat.exe --path.data "$Env:ProgramData\winlogbeat" keystore add REDIS_PASSWORD --stdin
+    } else {
+        .\winlogbeat.exe --path.data "$Env:ProgramData\winlogbeat" keystore add REDIS_PASSWORD
+    }
 }
 
 PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service-winlogbeat.ps1

--- a/agent/install-sysmon-beats.ps1
+++ b/agent/install-sysmon-beats.ps1
@@ -235,6 +235,7 @@ if (-not (Test-Path "$Env:programfiles\winlogbeat*" -PathType Container)) {
   Invoke-WebRequest -OutFile WinLogBeat.zip https://artifacts.elastic.co/downloads/beats/winlogbeat/winlogbeat-7.5.2-windows-x86_64.zip
   Expand-Archive .\WinLogBeat.zip
   rm .\WinLogBeat.zip
+  rm .\WinLogBeat\winlogbeat*\winlogbeat.yml
   mv .\WinLogBeat\winlogbeat* "$Env:programfiles"
 }
 


### PR DESCRIPTION
This PR moves the check for $Env:programfiles\Sysmon towards the top of the code before anything tries to use that directory.