### PR TITLE
Set minimum TLS version to 1.2 in winlogbeat config

### DIFF
--- a/agent/install-sysmon-beats.ps1
+++ b/agent/install-sysmon-beats.ps1
@@ -285,6 +285,7 @@ output.redis:
   ssl:
     enabled: true
     verification_mode: none
+    supported-protocols: [TLSv1.2, TLSv1.3]
   key: "net-data:sysmon"
   password: `"`${REDIS_PASSWORD}`"
 "@


### PR DESCRIPTION
I worked with a user running Windows 10 21H1 without the latest patches on installing the Espy agent and connecting it to the Espy server. We ran into a TLS version mismatch issue since Redis requires TLSv1.2 or 1.3 by default while winlogbeat defaulted to TLSv1.1. I had the user make the changes here and it resolved the related TLS issue.

Discord chat link: https://discordapp.com/channels/690293821866508430/806517137811701840/1016848674652954664

Closes #62
