### PR TITLE
Add documentation for forwarding logs to BeaKer's Elastic instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Elasticsearch:
   # Use the credentials created for BeaKer's ingestion tasks.
   # If the automated installer for BeaKer was used, the account is sysmon-ingest.
   User: "sysmon-ingest"
+  # If you forgot the password for the sysmon-ingest user, it can be reset within Kibana under Management>Security>Users
   Password: "password"
 
   TLS:

--- a/README.md
+++ b/README.md
@@ -101,12 +101,14 @@ Elasticsearch:
 ```
 
 Note that the configuration example sets the `Host` to the address of Docker's network bridge. This is a quick way to get Espy hooked up to BeaKer. If your network or Docker installation has a non-standard configuration, this change may not work. 
+
 Why?
+
 BeaKer exposes port `9200` for Elasticsearch, so the Elastic instance runs on the [Docker host's](https://www.google.com/search?q=docker+host) loopback address (`localhost`, `127.0.0.1`). This means that Elasticsearch/Kibana is accessible on your server/network and is not isolated to the Docker containers/network.
 Espy exposes port `6379` for Redis, so Redis is accessible on your server/network, and therefore is able to receive logs from endpoints with the Espy agent installed. Since winlogbeat only supports one output source, we cannot directly pass logs over to Elasticsearch and instead must forward logs over from Redis/Espy. Since Espy's event forwarder runs in a container, it does not have access to the server's loopback address via `localhost` or `127.0.0.1`. Therefore, setting the `Host` field in `espy.yaml` to `localhost:9200` or `127.0.0.1:9200` would be pointing to the Espy container's loopback address, which does not host the Elastic instance, so it would fail. 
 
 There are multiple ways to get a Docker container to be able to connect to the Docker host's network. [This tutorial](https://www.howtogeek.com/devops/how-to-connect-to-localhost-within-a-docker-container/) shows a few of those methods. If using `172.17.0.1` as the Elastic host address doesn't work for you, maybe some of these other methods will. Some methods do impose security risks, so be sure to review what would be exposed with each method. 
-One thing to note is that the forwarder receives the value of the `Host` parameter as a string, so using any Docker based variables that are usually used in Compose or Dockerfiles would not work unless Docker literally translates the routing address to the name of the variable. (i.e Can the Espy container reach https://host.docker.internal:9200/ ?)
+One thing to note is that the forwarder receives the value of the `Host` parameter as a string, so using any Docker based variables that are usually used in Compose or Dockerfiles would not work unless Docker literally translates the routing address to the name of the variable. (i.e Can the Espy container reach `https://host.docker.internal:9200/` ?)
 
 ### Data Collected By Sysmon Per Network Connection
 - Source

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ One of our open source tools, [BeaKer](https://github.com/activecm/BeaKer), uses
 
 - Find the address of Docker's network bridge (default is `172.17.0.1`):
   - `docker network inspect bridge --format '{{range .IPAM.Config}}{{.Gateway}}{{end}}'`
+  or
+  - `ip -br -c -f inet addr show docker0`
   
 In `/etc/espy/espy.yaml`, edit the `Elasticsearch` block as follows:
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Elasticsearch:
   # If the automated installer for BeaKer was used, the account is sysmon-ingest.
   User: "sysmon-ingest"
   # If you forgot the password for the sysmon-ingest user, it can be reset within Kibana under Management>Security>Users
-  # Resetting the password requires updating each Windows system running the **BeaKer** agent with the new password
+  # Resetting the password requires updating each Windows system running the BeaKer agent with the new password
   Password: "password"
 
   TLS:

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Elasticsearch:
   # If the automated installer for BeaKer was used, the account is sysmon-ingest.
   User: "sysmon-ingest"
   # If you forgot the password for the sysmon-ingest user, it can be reset within Kibana under Management>Security>Users
+  # Resetting the password requires updating each Windows system running the **BeaKer** agent with the new password
   Password: "password"
 
   TLS:


### PR DESCRIPTION
Closes #45

Adds instructions for wiring up Espy & Beaker by forwarding winlogbeat events from Espy agents to BeaKer's elasticsearch instance and subsequently Kibana. Since both Espy & Beaker use the same index name template, no configuration is needed to get espy events into the `sysmon-****-**-**` elastic index.

Documentation was created while assisting a user on the Theat Hunting discord to get espy event logs into BeaKer. Instructions were also followed locally and I was successfully able to view event logs from espy agents within Kibana. 