### PR TITLE
Upgrade Winlogbeat to v8.x

### DIFF
--- a/agent/install-sysmon-beats.ps1
+++ b/agent/install-sysmon-beats.ps1
@@ -49,109 +49,137 @@ enter the credentials during the installation process, or edit the parameters' d
 #>
 
 param (
-    [Parameter(Mandatory=$true)][string]$RedisHost,
-    [string]$RedisPort="6379",
-    [string]$RedisPassword="",
-    [string]$SysmonConfig=""
+  [Parameter(Mandatory = $true)][string]$RedisHost,
+  [string]$RedisPort = "6379",
+  [string]$RedisPassword = "",
+  [string]$SysmonConfig = "",
+  [string]$BeatsVersion = ""
+
 )
 
-if (-NOT ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator"))
-{
-    # Use param values instead of $args because $args doesn't appear to get populated if param values are specified
-    # Also set the ExecutionPolicy to Bypass otherwise this will likely fail as script
-    # execution is disabled by default.
-    $arguments = "-ExecutionPolicy", "Bypass", "-File", $myinvocation.mycommand.definition, $RedisHost, $RedisPort
-    if($RedisPassword) 
-    {
-        # Only add this argument if the user provided it, otherwise it will be blank and will cause an error
-        $arguments += $RedisPassword
-    }
+$ELK_STACK_VERSION = "8.6.2"
+
+[bool] $OverrideBeatsVersion = $false
+if ([string]::IsNullOrWhiteSpace("$BeatsVersion")) {
+  $BeatsVersion = "$ELK_STACK_VERSION"
+}
+else {
+  if ($null -eq ("$BeatsVersion" -as [System.Version])) {
+    throw "Beats version $BeatsVersion is not a valid version, please provide a valid version number."
+  }
+  if ([System.Version]$BeatsVersion -lt [System.Version]"7.17.9") {
+    throw "Minimum supported Beats version is 7.17.9, exiting"
+  }
+  $OverrideBeatsVersion = $true
+}
+
+# Check for existing winlogbeat installation via BeaKer
+if (Test-Path "$Env:programfiles\Winlogbeat-BeaKer" -PathType Container) {
+  Write-Output "Detected existing winlogbeat installation performed by Espy. Continuing the install may result in a partially working Sysmon/winlogbeat setup."
+  $installAnyway = Read-Host -Prompt "Are you sure you want to continue? [y/n]"
+  if (($installAnyway -eq 'n') -or ($installAnyway -eq 'N')) {
+    Exit
+  }
+}
+
+if (-NOT ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {
+  # Use param values instead of $args because $args doesn't appear to get populated if param values are specified
+  # Also set the ExecutionPolicy to Bypass otherwise this will likely fail as script
+  # execution is disabled by default.
+  $arguments = "-ExecutionPolicy", "Bypass", "-File", $myinvocation.mycommand.definition, $RedisHost, $RedisPort
+  if ($RedisPassword) {
+    # Only add this argument if the user provided it, otherwise it will be blank and will cause an error
+    $arguments += $RedisPassword
+  }
   
-    Start-Process -FilePath powershell -Verb runAs -ArgumentList $arguments
-    Break
+  Start-Process -FilePath powershell -Verb runAs -ArgumentList $arguments
+  Break
 }
 
 # Copy Sysmon into Program Files if it doesn't already exist
 if (-not (Test-Path "$Env:programfiles\Sysmon" -PathType Container)) {
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    Invoke-WebRequest -OutFile Sysmon.zip https://download.sysinternals.com/files/Sysmon.zip
-    Expand-Archive .\Sysmon.zip
-    rm .\Sysmon.zip
-    mv .\Sysmon\ "$Env:programfiles"
+  [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+  Invoke-WebRequest -OutFile Sysmon.zip https://download.sysinternals.com/files/Sysmon.zip
+  Expand-Archive .\Sysmon.zip
+  rm .\Sysmon.zip
+  mv .\Sysmon\ "$Env:programfiles"
 }
 
 # Set SysmonConfig by querying Sysmon if it has already been installed
 if ($SysmonConfig -eq "" -and (Test-Path "$Env:windir\Sysmon64.exe" -PathType Leaf)) {
-    $oldConfigPathLine = (& "$Env:windir\Sysmon64.exe" "-c" | Select-String " - Config file:").Line
-    $oldConfigPath = [RegEx]::Matches($oldConfigPathLine, "^ - Config file:\s*(\S.*)$").Groups[1].Value  # Returns "" if no match
-    if (Test-Path "$oldConfigPath" -PathType Leaf) {
-        $SysmonConfig = (Resolve-Path "$oldConfigPath").Path
-    } else {
-        throw "Sysmon is already installed, but the existing Sysmon configuration file could not be found"
-    }
+  $oldConfigPathLine = (& "$Env:windir\Sysmon64.exe" "-c" | Select-String " - Config file:").Line
+  $oldConfigPath = [RegEx]::Matches($oldConfigPathLine, "^ - Config file:\s*(\S.*)$").Groups[1].Value  # Returns "" if no match
+  if (Test-Path "$oldConfigPath" -PathType Leaf) {
+    $SysmonConfig = (Resolve-Path "$oldConfigPath").Path
+  }
+  else {
+    throw "Sysmon is already installed, but the existing Sysmon configuration file could not be found"
+  }
 }
 
 if ($SysmonConfig -ne "" -and (Test-Path "$SysmonConfig" -PathType Leaf)) {
-    [xml]$sysmonXML = $null
+  [xml]$sysmonXML = $null
 
-    $configPathAsURI =$sysmonConfig -as [System.URI]
-    if ($null -ne $configPathAsURI.AbsoluteURI -and $configPathAsURI.Scheme -match '[http|https]') {
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-        [xml]$sysmonXML = (Invoke-WebRequest -Uri "$SysmonConfig").Content
-    } else {
-        [xml]$sysmonXML = Get-Content "$SysmonConfig"
-    } 
+  $configPathAsURI = $sysmonConfig -as [System.URI]
+  if ($null -ne $configPathAsURI.AbsoluteURI -and $configPathAsURI.Scheme -match '[http|https]') {
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    [xml]$sysmonXML = (Invoke-WebRequest -Uri "$SysmonConfig").Content
+  }
+  else {
+    [xml]$sysmonXML = Get-Content "$SysmonConfig"
+  } 
 
-    $schemaVersionString = $sysmonXML.Sysmon.schemaversion
+  $schemaVersionString = $sysmonXML.Sysmon.schemaversion
 
-    if ($null -eq $schemaVersionString) {
-        # can't read existing schema version
-        throw "Could not read schema version from the provided Sysmon configuration file"
-    }
+  if ($null -eq $schemaVersionString) {
+    # can't read existing schema version
+    throw "Could not read schema version from the provided Sysmon configuration file"
+  }
 
-    $schemaVersionParts = $schemaVersionString.Split(".")
-    if ($schemaVersionParts.Length -ne 2) {
-        # can't parse existing schema version
-        throw "Could not parse schema version from the provided Sysmon configuration file"
-    }
+  $schemaVersionParts = $schemaVersionString.Split(".")
+  if ($schemaVersionParts.Length -ne 2) {
+    # can't parse existing schema version
+    throw "Could not parse schema version from the provided Sysmon configuration file"
+  }
 
-    if ($schemaVersionParts[0] -lt 4 -or $schemaVersionParts[0] -eq 4 -and $schemaVersionParts[1] -le 1) {
-        # can't upgrade configs from Sysmon 8 and lower
-        throw "The provided Sysmon configuration file is too old (schema version <= 4.1)"
-    }
+  if ($schemaVersionParts[0] -lt 4 -or $schemaVersionParts[0] -eq 4 -and $schemaVersionParts[1] -le 1) {
+    # can't upgrade configs from Sysmon 8 and lower
+    throw "The provided Sysmon configuration file is too old (schema version <= 4.1)"
+  }
 
-    if ($schemaVersionParts[0] -lt 4 -or $schemaVersionParts[0] -eq 4 -and $schemaVersionParts[1] -le 20) {
-        Write-Output "Upgrading Sysmon schema version from $schemaVersionString to 4.22"
-        $sysmonXML.Sysmon.schemaversion = "4.22"
-    }
+  if ($schemaVersionParts[0] -lt 4 -or $schemaVersionParts[0] -eq 4 -and $schemaVersionParts[1] -le 20) {
+    Write-Output "Upgrading Sysmon schema version from $schemaVersionString to 4.22"
+    $sysmonXML.Sysmon.schemaversion = "4.22"
+  }
 
-    if ($null -eq $sysmonXML.Sysmon.EventFiltering) {
-        # the EventFiltering node must exist
-        throw "The provided Sysmon configuration must define the EventFiltering section"
-    }
+  if ($null -eq $sysmonXML.Sysmon.EventFiltering) {
+    # the EventFiltering node must exist
+    throw "The provided Sysmon configuration must define the EventFiltering section"
+  }
 
-    # Remove NetworkConnect nodes
-    $networkConnectNodes = Select-Xml -Xpath "//Sysmon//NetworkConnect" -Xml $sysmonXML
-    foreach ($node in $networkConnectNodes) {
-        $node.Node.ParentNode.RemoveChild($node.Node) | Out-Null
-    }
+  # Remove NetworkConnect nodes
+  $networkConnectNodes = Select-Xml -Xpath "//Sysmon//NetworkConnect" -Xml $sysmonXML
+  foreach ($node in $networkConnectNodes) {
+    $node.Node.ParentNode.RemoveChild($node.Node) | Out-Null
+  }
 
-    $newNetworkConnectNode = $sysmonXML.CreateElement("NetworkConnect")
-    $newNetworkConnectNode.SetAttribute("onmatch", "exclude")
-    $sysmonXML.Sysmon.EventFiltering.AppendChild($newNetworkConnectNode) | Out-Null
+  $newNetworkConnectNode = $sysmonXML.CreateElement("NetworkConnect")
+  $newNetworkConnectNode.SetAttribute("onmatch", "exclude")
+  $sysmonXML.Sysmon.EventFiltering.AppendChild($newNetworkConnectNode) | Out-Null
 
-    $dnsQueryNodes = Select-Xml -Xpath "//Sysmon//DnsQuery" -Xml $sysmonXML
-    foreach ($node in $dnsQueryNodes) {
-        $node.Node.ParentNode.RemoveChild($node.Node) | Out-Null
-    }
+  $dnsQueryNodes = Select-Xml -Xpath "//Sysmon//DnsQuery" -Xml $sysmonXML
+  foreach ($node in $dnsQueryNodes) {
+    $node.Node.ParentNode.RemoveChild($node.Node) | Out-Null
+  }
 
-    $newDnsQueryNode = $sysmonXML.CreateElement("DnsQuery")
-    $newDnsQueryNode.SetAttribute("onmatch", "exclude")
-    $sysmonXML.Sysmon.EventFiltering.AppendChild($newDnsQueryNode) | Out-Null
+  $newDnsQueryNode = $sysmonXML.CreateElement("DnsQuery")
+  $newDnsQueryNode.SetAttribute("onmatch", "exclude")
+  $sysmonXML.Sysmon.EventFiltering.AppendChild($newDnsQueryNode) | Out-Null
     
-    Write-Output $sysmonXML.OuterXml > "$Env:programfiles\Sysmon\sysmon-espy.xml"
-} else {
-    Write-Output @"
+  Write-Output $sysmonXML.OuterXml > "$Env:programfiles\Sysmon\sysmon-espy.xml"
+}
+else {
+  Write-Output @"
 <Sysmon schemaversion="4.22">
     <HashAlgorithms>md5,sha256,IMPHASH</HashAlgorithms>
     <EventFiltering>
@@ -227,30 +255,96 @@ if ($SysmonConfig -ne "" -and (Test-Path "$SysmonConfig" -PathType Leaf)) {
 
 # Load the new sysmon configuration and install the service if needed
 if (Test-Path "$Env:windir\Sysmon64.exe" -PathType Leaf) {
-    & "$Env:programfiles\Sysmon\Sysmon64.exe" -c "$Env:programfiles\Sysmon\sysmon-espy.xml"
-} else {
-    & "$Env:programfiles\Sysmon\Sysmon64.exe" -accepteula -i "$Env:programfiles\Sysmon\sysmon-espy.xml"
+  & "$Env:programfiles\Sysmon\Sysmon64.exe" -c "$Env:programfiles\Sysmon\sysmon-espy.xml"
+}
+else {
+  & "$Env:programfiles\Sysmon\Sysmon64.exe" -accepteula -i "$Env:programfiles\Sysmon\sysmon-espy.xml"
 }
 
-# Download winlogbeat if it doesn't exist
-if (-not (Test-Path "$Env:programfiles\winlogbeat*" -PathType Container)) {
+$InstalledBeatsVersion = ""
+[bool] $DownloadWinlogbeat = $false
+
+# Check for fresh install or pre-7.17 install
+if (-not (Test-Path "$Env:programfiles\Winlogbeat-Espy\winlogbeat.exe" -PathType Leaf)) {
+  $DownloadWinlogbeat = $true
+  
+  # Create install directory if it doesn't exist
+  if (-not (Test-Path "$Env:programfiles\Winlogbeat-Espy" -PathType Container)) {
+    mkdir "$Env:programfiles\Winlogbeat-Espy" > $null
+  }
+  
+  # Check if this is a pre-7.17 upgrade install
+  if ((Test-Path "$Env:programfiles\winlogbeat-7*" -PathType Container)) {
+    ### Make sure that Beats is upgraded to 7.17 before installing v8.x
+    # Install winlogbeat 7.17.9 if the current version is less than 8.x
+    if (!$OverrideBeatsVersion) {
+      $BeatsVersion = "7.17.9"
+    }
+    Copy-Item "$Env:programfiles\winlogbeat-7*\winlogbeat.yml" "$Env:programfiles\Winlogbeat-Espy"
+  }
+}
+else {
+  # Check if currently installed version is outdated
+  $InstalledBeatsVersion = (& "$Env:programfiles\Winlogbeat-Espy\winlogbeat.exe" version | Select-String -Pattern "(?<=winlogbeat version )(\d+\.\d+\.\d+)").Matches.Value
+  if ($null -eq ("$InstalledBeatsVersion" -as [System.Version])) {
+  
+    if (!$OverrideBeatsVersion) {
+      throw "Unable to retrieve installed winlogbeat version"
+    }
+    else {
+      Write-Output "Unable to retrieve installed winlogbeat version, continuing anyway"
+      $DownloadWinlogbeat = $true
+    }
+  }
+  else {
+    if ([System.Version]"$InstalledBeatsVersion" -lt [System.Version]"$BeatsVersion") {
+      $DownloadWinlogbeat = $true
+    }
+  }
+}
+
+# Download winlogbeat and move it to install directory
+if ($DownloadWinlogbeat) {
+  Write-Output "######## Downloading winlogbeat version $BeatsVersion ########"
+
   [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-  Invoke-WebRequest -OutFile WinLogBeat.zip https://artifacts.elastic.co/downloads/beats/winlogbeat/winlogbeat-7.5.2-windows-x86_64.zip
+  Invoke-WebRequest -OutFile WinLogBeat.zip https://artifacts.elastic.co/downloads/beats/winlogbeat/winlogbeat-"$BeatsVersion"-windows-x86_64.zip
   Expand-Archive .\WinLogBeat.zip
   rm .\WinLogBeat.zip
   rm .\WinLogBeat\winlogbeat*\winlogbeat.yml
-  mv .\WinLogBeat\winlogbeat* "$Env:programfiles"
+
+  # Stop winlogbeat service if it exists 
+  if (Get-Service winlogbeat -ErrorAction SilentlyContinue) {
+    Stop-Service winlogbeat
+    (Get-Service winlogbeat).WaitForStatus('Stopped')
+    Start-Sleep -s 1
+  }
+  Copy-Item -Path .\WinLogBeat\winlogbeat*\* -Destination "$Env:programfiles\Winlogbeat-Espy\" -Recurse -Force
+  rm .\Winlogbeat -Recurse
 }
 
+Write-Output "######## Installing winlogbeat version $BeatsVersion ########"
+
 # Begin winlogbeat configuration
-Set-Location "$Env:programfiles\winlogbeat*\"
+Set-Location "$Env:programfiles\Winlogbeat-Espy\"
 
 # Backup winlogbeat config if it exists
 if (Test-Path -PathType Leaf .\winlogbeat.yml) {
+  if ($DownloadWinlogbeat) {
+    # Backup config with its version in the name if upgrading to a new Beats version
+    # so that the config isn't overwritten by subsequent upgrades. This is useful in case
+    # breaking changes between configurations need to be referenced in the future for troubleshooting
+    Copy-Item .\winlogbeat.yml .\winlogbeat-$InstalledBeatsVersion-old.yml.bak
+  }
+  else {
     Copy-Item .\winlogbeat.yml .\winlogbeat.yml.bak
+  }
 }
 
-$winlogbeatSysmonCfg = @"
+$winlogbeatSysmonCfg = ""
+
+if ([System.Version]$BeatsVersion -lt [System.Version]"8.0.0") {
+  $winlogbeatSysmonCfg = @"
 winlogbeat.event_logs:
   - name: Microsoft-Windows-Sysmon/Operational
     event_id: 3, 22
@@ -263,19 +357,61 @@ winlogbeat.event_logs:
           netinfo:
             enabled: true
 "@
+}
+else {
+  $winlogbeatSysmonCfg = @"
+winlogbeat.event_logs:
+  - name: Microsoft-Windows-Sysmon/Operational
+    event_id: 3, 22
+"@
+}
 
 # Add the windows event logs config to winlogbeat if it doesn't exist.
 if ((Test-Path -PathType Leaf .\winlogbeat.yml) -and 
     ((Get-Content -Raw .\winlogbeat.yml | Select-String "winlogbeat\.event_logs:").Matches.Length -gt 0)) {
+
+  # Attempt to remove the "- script" entry that points to winlogbeat-sysmon.js if installing v8.x
+  # Starting winlogbeat with this entry in the config on v8.x will fail
+  if (([System.Version]$BeatsVersion -ge [System.Version]"8.0.0") -and 
+      ((Get-Content -Raw .\winlogbeat.yml | Select-String "winlogbeat-sysmon.js").Matches.Length -gt 0)) {
+    
+    # Find "- script" entries
+    $scriptEntries = Get-Content .\winlogbeat.yml | Select-String "- script" | Select-Object LineNumber
+
+    foreach ($match in $scriptEntries) {
+      $endLine = $match.LineNumber + 3
+    
+      $scriptBlock = @() # array to hold the lines in the script block
+
+      [bool] $isMatch = $false
+
+      # Look through each line in the block and verify that it contains winlogbeat-sysmon.js
+      for (($i = $match.LineNumber); $i -ile $endLine; $i++) {
+        $line = Get-Content .\winlogbeat.yml | Select -First 1 -Skip ($i - 1)
+        $scriptBlock += $line
+        if (($line | Select-String "winlogbeat-sysmon.js").Matches.Length -gt 0) {
+          $isMatch = $true
+        }
+      }
+      if ($isMatch) {
+        # Diff between the full config file and the script block
+        # Replace the config with the script block removed
+        Compare-Object (Get-Content .\winlogbeat.yml) $scriptBlock | Select-Object -ExpandProperty InputObject | Set-Content .\winlogbeat.yml
+      }
+    }
+  }
+  else {
     Write-Output "Found Event Logs stanza in the existing winlogbeat configuration"
     Write-Output "Refusing to update winlogbeat Event Logs configuration"
     Write-Output "Please ensure the following configuration is present in`n`t$( (Resolve-Path .).Path )\winlogbeat.yml:"
     Write-Output ""
     Write-Output "$winlogbeatSysmonCfg"
     Write-Output ""
-} else {
-    Write-Output "" >> .\winlogbeat.yml
-    Write-Output "$winlogbeatSysmonCfg" >> .\winlogbeat.yml
+  }
+}
+else {
+  Write-Output "" >> .\winlogbeat.yml
+  Write-Output "$winlogbeatSysmonCfg" >> .\winlogbeat.yml
 }
 
 $winlogbeatRedisCfg = @"
@@ -292,32 +428,34 @@ output.redis:
 
 if ((Test-Path -PathType Leaf .\winlogbeat.yml) -and 
     ((Get-Content -Raw .\winlogbeat.yml | Select-String "output\.redis:").Matches.Length -gt 0)) {
-    Write-Output "Found Redis stanza in the existing winlogbeat configuration"
-    Write-Output "Refusing to update winlogbeat Redis configuration"
-    Write-Output "Please ensure the following configuration is present in`n`t$( (Resolve-Path .).Path )\winlogbeat.yml:"
-    Write-Output ""
-    Write-Output "$winlogbeatRedisCfg"
-    Write-Output ""
-} else {
-    Write-Output "" >> .\winlogbeat.yml
-    Write-Output "$winlogbeatRedisCfg" >> .\winlogbeat.yml
+  Write-Output "Found Redis stanza in the existing winlogbeat configuration"
+  Write-Output "Refusing to update winlogbeat Redis configuration"
+  Write-Output "Please ensure the following configuration is present in`n`t$( (Resolve-Path .).Path )\winlogbeat.yml:"
+  Write-Output ""
+  Write-Output "$winlogbeatRedisCfg"
+  Write-Output ""
+}
+else {
+  Write-Output "" >> .\winlogbeat.yml
+  Write-Output "$winlogbeatRedisCfg" >> .\winlogbeat.yml
 }
 
 # Create the keystore if it doesn't exist
 if (-not (Test-Path -PathType Leaf "$Env:ProgramData\winlogbeat\winlogbeat.keystore")) {
-    .\winlogbeat.exe --path.data "$Env:ProgramData\winlogbeat" keystore create
-    # Set ACL's of the $Env:ProgramData\winlogbeat folder to be the same as $Env:ProgramFiles\winlogbeat* (the main install path)
-    # This helps ensure that "normal" users aren't able to access the $Env:ProgramData\winlogbeat folder
-    Get-ACL -Path "$Env:ProgramFiles\winlogbeat*" | Set-ACL -Path "$Env:ProgramData\winlogbeat"
+  .\winlogbeat.exe --path.data "$Env:ProgramData\winlogbeat" keystore create
+  # Set ACL's of the $Env:ProgramData\winlogbeat folder to be the same as $Env:ProgramFiles\winlogbeat* (the main install path)
+  # This helps ensure that "normal" users aren't able to access the $Env:ProgramData\winlogbeat folder
+  Get-ACL -Path "$Env:ProgramFiles\Winlogbeat-Espy\" | Set-ACL -Path "$Env:ProgramData\winlogbeat"
 }
 
 # Set the Redis password if it doesn't exist
 if ((.\winlogbeat.exe --path.data "$Env:ProgramData\winlogbeat" keystore list | Select-String REDIS_PASSWORD).Matches.Length -eq 0) {
-    if($RedisPassword) {
-        Write-Output "$RedisPassword" | .\winlogbeat.exe --path.data "$Env:ProgramData\winlogbeat" keystore add REDIS_PASSWORD --stdin
-    } else {
-        .\winlogbeat.exe --path.data "$Env:ProgramData\winlogbeat" keystore add REDIS_PASSWORD
-    }
+  if ($RedisPassword) {
+    Write-Output "$RedisPassword" | .\winlogbeat.exe --path.data "$Env:ProgramData\winlogbeat" keystore add REDIS_PASSWORD --stdin
+  }
+  else {
+    .\winlogbeat.exe --path.data "$Env:ProgramData\winlogbeat" keystore add REDIS_PASSWORD
+  }
 }
 
 PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service-winlogbeat.ps1

--- a/agent/install-sysmon-beats.ps1
+++ b/agent/install-sysmon-beats.ps1
@@ -34,6 +34,10 @@ The following changes are made to the given configuration file:
 
 The schema version of the given Sysmon configuration must be greater than version 4.1.
 
+.PARAMETER BeatsVersion
+The version of Winlogbeat to install. This will override any logic that handles upgrading to an
+intermediate version of Winlogbeat before upgrading to a higher major version.
+
 .EXAMPLE
 # Asks for Redis authentication details at runtime
 .\install-sysmon-beats.ps1 my-redis-host.com 6379
@@ -57,7 +61,7 @@ param (
 
 )
 
-$ELK_STACK_VERSION = "8.6.2"
+$ELK_STACK_VERSION = "8.7.0"
 
 [bool] $OverrideBeatsVersion = $false
 if ([string]::IsNullOrWhiteSpace("$BeatsVersion")) {
@@ -75,7 +79,7 @@ else {
 
 # Check for existing winlogbeat installation via BeaKer
 if (Test-Path "$Env:programfiles\Winlogbeat-BeaKer" -PathType Container) {
-  Write-Output "Detected existing winlogbeat installation performed by Espy. Continuing the install may result in a partially working Sysmon/winlogbeat setup."
+  Write-Output "Detected existing winlogbeat installation performed by BeaKer. Continuing the install may result in a partially working Sysmon/winlogbeat setup."
   $installAnyway = Read-Host -Prompt "Are you sure you want to continue? [y/n]"
   if (($installAnyway -eq 'n') -or ($installAnyway -eq 'N')) {
     Exit

--- a/espy/input/ecs.go
+++ b/espy/input/ecs.go
@@ -1,10 +1,33 @@
 package input
 
-import "errors"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
 
 var ErrMalformedECSRecord = errors.New("encountered malformed data in ECSRecord")
 
-//ECSRecord is the union of Elastic comma schema fields used by *beats software
+type Metadata struct {
+	Version string `json:"version"`
+}
+
+type ECSMetadata struct {
+	Metadata Metadata `json:"@metadata"`
+}
+
+type Answer struct {
+	Type string
+	Data string
+}
+
+// ECSRecord is the union of Elastic comma schema fields used by *beats software
 type ECSRecord struct {
 	RFCTimestamp string `json:"@timestamp"`
 	// Type string // Not supported by sysmon/ winlogbeat. Use with packetbeat.
@@ -18,13 +41,13 @@ type ECSRecord struct {
 	}
 	Source struct {
 		IP   string
-		Port int
+		Port json.Number
 		// Bytes   int64 // Not supported by sysmon/ winlogbeat. Use with packetbeat.
 		// Packets int64 // Not supported by sysmon/ winlogbeat. Use with packetbeat.
 	}
 	Destination struct {
 		IP   string
-		Port int
+		Port json.Number
 		//		Bytes   int64 // Not supported by sysmon/ winlogbeat. Use with packetbeat.
 		//		Packets int64 // Not supported by sysmon/ winlogbeat. Use with packetbeat.
 	}
@@ -35,15 +58,230 @@ type ECSRecord struct {
 	Event struct {
 		//		Duration float64 // Not supported by sysmon/ winlogbeat. Use with packetbeat.
 		Provider string
-		Code     int
+		Code     json.Number
 	}
 	DNS struct {
-		Answers []struct {
-			Type string
-			Data string
-		}
+		Answers  []Answer
 		Question struct {
 			Name string
 		}
 	}
+}
+
+type EventDatav8 struct {
+	SourceIp            string
+	SourcePort          string
+	DestinationIp       string
+	DestinationPort     string
+	Protocol            string // ECS Transport, RITA Proto
+	DestinationPortName string // ECS Protocol, RITA Service
+	QueryName           string
+	QueryResults        string
+	UtcTime             string
+}
+
+type ECSRecordv8 struct {
+	RFCTimestamp string `json:"@timestamp"`
+	// Type string // Not supported by sysmon/ winlogbeat. Use with packetbeat.
+
+	Agent struct {
+		Name string
+		ID   string
+	}
+
+	Host struct {
+		IP []string
+	}
+
+	Winlog struct {
+		EventData EventDatav8 `json:"event_data"`
+	}
+
+	Event struct {
+		Provider string
+		Code     string
+	}
+}
+
+// Processes a v8.x event log and converts it into an ECSRecord
+func (r *ECSRecordv8) Process() (*ECSRecord, error) {
+	newRecord := &ECSRecord{
+		Host: r.Host,
+	}
+	// Timestamp
+	// Attempt to parse UtcTime in its expected format and replace @timestamp with it
+	utcTime, err := time.Parse("2006-01-02 15:04:05.999", r.Winlog.EventData.UtcTime)
+	if err != nil {
+		newRecord.RFCTimestamp = r.RFCTimestamp
+	} else {
+		newRecord.RFCTimestamp = utcTime.Format(time.RFC3339Nano)
+	}
+
+	// Agent
+	newRecord.Agent.Hostname = r.Agent.Name
+	newRecord.Agent.ID = r.Agent.ID
+
+	// Source
+	newRecord.Source.IP = r.Winlog.EventData.SourceIp
+	if r.Winlog.EventData.SourcePort != "" && r.Winlog.EventData.SourcePort != "-" {
+		srcPort, err := strconv.Atoi(r.Winlog.EventData.SourcePort)
+		if err != nil {
+			log.WithError(err).WithField("EventData Source Port", r.Winlog.EventData.SourcePort).Error(err.Error())
+		} else {
+			newRecord.Source.Port = json.Number(fmt.Sprint(srcPort))
+		}
+	}
+
+	// Destination
+	newRecord.Destination.IP = r.Winlog.EventData.DestinationIp
+	if r.Winlog.EventData.DestinationPort != "" && r.Winlog.EventData.DestinationPort != "-" {
+		dstPort, err := strconv.Atoi(r.Winlog.EventData.DestinationPort)
+		if err != nil {
+			log.WithError(err).WithField("EventData Destination Port", r.Winlog.EventData.DestinationPort).Error(err.Error())
+		} else {
+			newRecord.Destination.Port = json.Number(fmt.Sprint(dstPort))
+		}
+	}
+
+	// Network
+	newRecord.Network.Transport = r.Winlog.EventData.Protocol
+	newRecord.Network.Protocol = r.Winlog.EventData.DestinationPortName
+
+	// Event
+	evtCode, err := strconv.Atoi(r.Event.Code)
+	if err != nil {
+		return nil, errors.New(err.Error() + " " + r.Event.Code)
+	}
+	if evtCode == 22 {
+		newRecord.Network.Protocol = "dns"
+	}
+	newRecord.Event.Code = json.Number(fmt.Sprint(evtCode))
+	newRecord.Event.Provider = r.Event.Provider
+
+	// DNS
+	newRecord.DNS.Question.Name = r.Winlog.EventData.QueryName
+	newRecord.DNS.Answers = parseDNSAnswers(r.Winlog.EventData.QueryResults)
+
+	return newRecord, nil
+}
+
+// Parses the DNS answers from the QueryResults string
+func parseDNSAnswers(rawData string) []Answer {
+	var answers []Answer
+	if rawData == "" {
+		return answers
+	}
+
+	// rawAnswers := "type:  5 a-ring.a-9999.a-msedge.net;type:  5 a-9999.a-msedge.net;::ffff:204.79.197.254;"
+	rawAnswers := strings.Split(rawData, ";")
+	for _, ans := range rawAnswers {
+		if len(ans) > 0 {
+			answerType := ""
+			answerData := ans
+			hasType := strings.HasPrefix(ans, "type:")
+			if hasType {
+				answerGroup := strings.Fields(ans)
+				// If the entry starts with type:, then there should be 3 groups separated by whitespace
+				if len(answerGroup) != 3 {
+					continue
+				}
+				answerType = getDNSRecordTypes(answerGroup[1])
+				answerData = answerGroup[2]
+
+				answer := Answer{
+					Type: answerType,
+					Data: answerData,
+				}
+
+				answers = append(answers, answer)
+
+			} else {
+				// if there is no type, then treat it as an IP address
+				answerData = strings.Replace(ans, "::ffff:", "", 1)
+				if net.ParseIP(answerData) != nil {
+					answerType = "A"
+					if strings.Contains(answerData, ":") {
+						answerType = "AAAA"
+					}
+
+					answer := Answer{
+						Type: answerType,
+						Data: answerData,
+					}
+					answers = append(answers, answer)
+				}
+			}
+		}
+	}
+	return answers
+}
+
+func getDNSRecordTypes(dtype string) string {
+	dnsRecordTypes := map[string]string{
+		"1":     "A",
+		"2":     "NS",
+		"3":     "MD",
+		"4":     "MF",
+		"5":     "CNAME",
+		"6":     "SOA",
+		"7":     "MB",
+		"8":     "MG",
+		"9":     "MR",
+		"10":    "NULL",
+		"11":    "WKS",
+		"12":    "PTR",
+		"13":    "HINFO",
+		"14":    "MINFO",
+		"15":    "MX",
+		"16":    "TXT",
+		"17":    "RP",
+		"18":    "AFSDB",
+		"19":    "X25",
+		"20":    "ISDN",
+		"21":    "RT",
+		"22":    "NSAP",
+		"23":    "NSAPPTR",
+		"24":    "SIG",
+		"25":    "KEY",
+		"26":    "PX",
+		"27":    "GPOS",
+		"28":    "AAAA",
+		"29":    "LOC",
+		"30":    "NXT",
+		"31":    "EID",
+		"32":    "NIMLOC",
+		"33":    "SRV",
+		"34":    "ATMA",
+		"35":    "NAPTR",
+		"36":    "KX",
+		"37":    "CERT",
+		"38":    "A6",
+		"39":    "DNAME",
+		"40":    "SINK",
+		"41":    "OPT",
+		"43":    "DS",
+		"46":    "RRSIG",
+		"47":    "NSEC",
+		"48":    "DNSKEY",
+		"49":    "DHCID",
+		"100":   "UINFO",
+		"101":   "UID",
+		"102":   "GID",
+		"103":   "UNSPEC",
+		"248":   "ADDRS",
+		"249":   "TKEY",
+		"250":   "TSIG",
+		"251":   "IXFR",
+		"252":   "AXFR",
+		"253":   "MAILB",
+		"254":   "MAILA",
+		"255":   "ANY",
+		"65281": "WINS",
+		"65282": "WINSR",
+	}
+	recordType, ok := dnsRecordTypes[dtype]
+	if ok {
+		return recordType
+	}
+	return ""
 }

--- a/espy/output/ecs.go
+++ b/espy/output/ecs.go
@@ -4,7 +4,7 @@ import (
 	"github.com/activecm/espy/espy/input"
 )
 
-//ECSWriter writes out deserialized Elastic Common Schema records
+// ECSWriter writes out deserialized Elastic Common Schema records
 type ECSWriter interface {
 	//WriteECSRecords writes out deserialized ECS records
 	WriteECSRecords(outputData []input.ECSRecord) error

--- a/espy/output/json.go
+++ b/espy/output/json.go
@@ -3,7 +3,7 @@ package output
 // JSONWriter writes a log entry in raw json format to a destination
 type JSONWriter interface {
 	//WriteECSRecords writes out JSON formatted ECS records
-	WriteECSRecords(outputData []string) error
+	WriteECSRecords(outputData []string, beatsVersion string) error
 	//Close frees any resources held by this writer
 	Close() error
 }

--- a/espy/output/zeek/conn.go
+++ b/espy/output/zeek/conn.go
@@ -52,28 +52,28 @@ func (c ConnTSV) FormatLines(outputData []input.ECSRecord) (output string, err e
 
 		values := []string{
 			fmt.Sprintf("%.6f", float64(goStartTime.UnixNano())/1e9), // "ts"
-			header.UnsetField,                            // "uid"
-			outputData[i].Source.IP,                      // "id.orig_h"
-			strconv.Itoa(outputData[i].Source.Port),      // "id.orig_p"
-			outputData[i].Destination.IP,                 // "id.resp_h"
-			strconv.Itoa(outputData[i].Destination.Port), // "id.resp_p",
-			outputData[i].Network.Transport,              // "proto"
-			outputData[i].Network.Protocol,               // "service"
-			header.UnsetField,                            // "duration"
-			header.UnsetField,                            // "orig_bytes"
-			header.UnsetField,                            // "resp_bytes"
-			header.UnsetField,                            // "conn_state",
-			"F",                                          // "local_orig"
-			"F",                                          // "local_resp"
-			header.UnsetField,                            // "missed_bytes"
-			header.UnsetField,                            // "history"
-			header.UnsetField,                            // "orig_pkts",
-			header.UnsetField,                            // "orig_ip_bytes"
-			header.UnsetField,                            // "resp_pkts"
-			header.UnsetField,                            // "resp_ip_bytes"
-			header.EmptyField,                            // "tunnel_parents",
-			outputData[i].Agent.ID,                       // "agent_uuid"
-			outputData[i].Agent.Hostname,                 // "agent_hostname",
+			header.UnsetField,                       // "uid"
+			outputData[i].Source.IP,                 // "id.orig_h"
+			outputData[i].Source.Port.String(),      // "id.orig_p"
+			outputData[i].Destination.IP,            // "id.resp_h"
+			outputData[i].Destination.Port.String(), // "id.resp_p",
+			outputData[i].Network.Transport,         // "proto"
+			outputData[i].Network.Protocol,          // "service"
+			header.UnsetField,                       // "duration"
+			header.UnsetField,                       // "orig_bytes"
+			header.UnsetField,                       // "resp_bytes"
+			header.UnsetField,                       // "conn_state",
+			"F",                                     // "local_orig"
+			"F",                                     // "local_resp"
+			header.UnsetField,                       // "missed_bytes"
+			header.UnsetField,                       // "history"
+			header.UnsetField,                       // "orig_pkts",
+			header.UnsetField,                       // "orig_ip_bytes"
+			header.UnsetField,                       // "resp_pkts"
+			header.UnsetField,                       // "resp_ip_bytes"
+			header.EmptyField,                       // "tunnel_parents",
+			outputData[i].Agent.ID,                  // "agent_uuid"
+			outputData[i].Agent.Hostname,            // "agent_hostname",
 		}
 
 		lastIdx := len(values) - 1
@@ -89,7 +89,7 @@ func (c ConnTSV) FormatLines(outputData []input.ECSRecord) (output string, err e
 }
 
 func (c ConnTSV) HandlesECSRecord(data input.ECSRecord) bool {
-	return data.Event.Provider == "Microsoft-Windows-Sysmon" && data.Event.Code == 3
+	return data.Event.Provider == "Microsoft-Windows-Sysmon" && data.Event.Code.String() == "3"
 }
 
 func init() {

--- a/espy/output/zeek/dns.go
+++ b/espy/output/zeek/dns.go
@@ -213,7 +213,7 @@ func (c DnsTSV) FormatLines(outputData []input.ECSRecord) (output string, err er
 }
 
 func (c DnsTSV) HandlesECSRecord(data input.ECSRecord) bool {
-	return data.Event.Provider == "Microsoft-Windows-Sysmon" && data.Event.Code == 22
+	return data.Event.Provider == "Microsoft-Windows-Sysmon" && data.Event.Code.String() == "22"
 }
 
 func init() {


### PR DESCRIPTION
Closes #67 
Somewhat depends on https://github.com/activecm/BeaKer/pull/75

#### Agent Changes:

- Changes the install directory from `C:\Program Files\winlogbeat-*` to `C:\Program Files\Winlogbeat-Espy` in order to be able to install newer versions of winlogbeat and more easily detect the currently installed version
- Adds a parameter, `BeatsVersion`, that allows the desired version of winlogbeat to be installed to be overridden
- Updates the `winlogbeat.yml` config as needed for 7.17 and 8.x 
  - When upgrading to v8.x, the `- script` entry within `processors` that refers to `winlogbeat-sysmon.js` is removed because it will cause winlogbeat to not run if it still exists
  

### Server Changes:
- Changes data parsed as integers to `json.Number`, as newer versions of Winlogbeat use strings to represent numbers. This data type makes it easy to parse both integers and strings using the same struct field and not requiring a custom unmarshaller
- Creates a new data type for Winlogbeat v8.x logs, as the sysmon processor for v8.x no longer exists on the agent system and is handled exclusively by Elasticsearch. Since espy does not require the use of Elasticsearch, the data is manually parsed by hand and converted to the standard `ECSRecord` type.
- Sends the ECS data to Elasticsearch using different URLs depending on the version of Winlogbeat the log came from