### PR TITLE
Don't use sudo when calling install_docker.sh

### DIFF
--- a/scripts/installer/stage/Espy/install_espy.sh
+++ b/scripts/installer/stage/Espy/install_espy.sh
@@ -45,7 +45,7 @@ test_system () {
 
 install_docker () {
     status "Installing Docker"
-    $SUDO ./scripts/shell-lib/docker/install_docker.sh
+    ./scripts/shell-lib/docker/install_docker.sh
     echo2 ''
     if $SUDO docker ps &>/dev/null ; then
 		echo2 'Docker appears to be working, continuing.'


### PR DESCRIPTION
Changes the call to install_docker.sh to not use sudo. 

`install_docker.sh` will now change the permissions of `/root/.docker/` instead of `/home/$USER/.docker` if called with `sudo`. This is due to a dependence on the `$HOME` and `$USER` environment variables (https://github.com/activecm/shell-lib/pull/32/files#diff-f3e0a0941c66122866ca45f12d8b454acd151795c087ccdcbd0d1b6c7205040eR200). Previously, the script did not handle setting the permissions of this folder since docker compose v1 did not need the user to be able to access this folder without `sudo`.