### PR TITLE
Add add_host_metadata processor to fresh winlogbeat v8 configs

### DIFF
--- a/agent/install-sysmon-beats.ps1
+++ b/agent/install-sysmon-beats.ps1
@@ -375,6 +375,10 @@ else {
 winlogbeat.event_logs:
   - name: Microsoft-Windows-Sysmon/Operational
     event_id: 3, 22
+    processors:
+      - add_host_metadata:
+          netinfo:
+            enabled: true
 "@
 }
 


### PR DESCRIPTION
Closes #74

Steps for reproducing the issue:
- Create a fresh installation of Espy
- Perform a fresh Winlogbeat installation with the Espy installation script
- Generate DNS traffic on the machine running Winlogbeat (browse the web for a bit)
- Check the sysmon log (Applications and Services/Microsoft/Windows/Sysmon/Operational) in the Windows event viewer and ensure there are entries with the event ID 22
- Check the file /opt/zeek/logs/ecs-spool/dns.log for DNS log entries

When running with the current master branch, there will not be any entries in the DNS log. 
If you edit the agent config to match what is here or perform the winlogbeat installation with the agent installer in this PR, there will be entries in the DNS log.